### PR TITLE
Exec the cancel returned by context.WithTimeout

### DIFF
--- a/timeout.go
+++ b/timeout.go
@@ -22,17 +22,20 @@ func (s *timeoutManager) Open() (err error)  { return s.chain.Open() }
 func (s *timeoutManager) Close() (err error) { return s.chain.Close() }
 
 func (s *timeoutManager) Put(ctx context.Context, key string, val []byte) (err error) {
-	ctx, _ = context.WithTimeout(ctx, s.timeout)
+	ctx, cancel = context.WithTimeout(ctx, s.timeout)
+	defer cancel()
 	return s.chain.Put(ctx, key, val)
 }
 
 func (s *timeoutManager) Get(ctx context.Context, key string) (data []byte, err error) {
-	ctx, _ = context.WithTimeout(ctx, s.timeout)
+	ctx, cancel = context.WithTimeout(ctx, s.timeout)
+	defer cancel()
 	return s.chain.Get(ctx, key)
 }
 
 func (s *timeoutManager) Del(ctx context.Context, key string) (err error) {
-	ctx, _ = context.WithTimeout(ctx, s.timeout)
+	ctx, cancel = context.WithTimeout(ctx, s.timeout)
+	defer cancel()
 	return s.chain.Del(ctx, key)
 
 }


### PR DESCRIPTION
the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak.